### PR TITLE
Remove support of `escape-output`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.4.1 (2023-09-25)
+------------------
+* Remvoe ``escape_output`` due it's deprecation
+
 0.4.0 (2023-09-11)
 ------------------
 * Make possible to pass ``resource_kwargs`` in ViewSets

--- a/import_export_extensions/__init__.py
+++ b/import_export_extensions/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Saritasa"""
 __email__ = "pypi@saritasa.com"
-__version__ = "0.4.0-alpha"
+__version__ = "0.4.1-alpha"

--- a/import_export_extensions/admin/mixins/export_mixin.py
+++ b/import_export_extensions/admin/mixins/export_mixin.py
@@ -69,7 +69,6 @@ class CeleryExportAdminMixin(
         """Provide escape settings to resource kwargs."""
         kwargs = super().get_export_resource_kwargs(request, *args, **kwargs)
         kwargs.update({
-            "escape_output": self.should_escape_output,
             "escape_html": self.should_escape_html,
             "escape_formulae": self.should_escape_formulae,
         })

--- a/import_export_extensions/models/export_job.py
+++ b/import_export_extensions/models/export_job.py
@@ -335,7 +335,6 @@ class ExportJob(TimeStampedModel):
         # file object (formats inherited from `BaseZipExport`)
         export_data = self.file_format.export_data(
             dataset=self.result,
-            escape_output=self.resource_kwargs.get("escape_output", False),
             escape_html=self.resource_kwargs.get("escape_html", False),
             escape_formulae=self.resource_kwargs.get("escape_formulae", False),
         )


### PR DESCRIPTION
According [import-export issue](https://github.com/django-import-export/django-import-export/pull/1618), `escape_output` parameter become deprecated during tablib update.
So it is need to be removed.

To reproduce run `inv tests.run` in main branch