### PR TITLE
Update format choice select for import admin pages

### DIFF
--- a/import_export_extensions/admin/mixins/import_mixin.py
+++ b/import_export_extensions/admin/mixins/import_mixin.py
@@ -285,7 +285,7 @@ class CeleryImportAdminMixin(
             if job.import_status != models.ImportJob.ImportStatus.PARSED:
                 # display import form
                 context["import_form"] = base_forms.ImportForm(
-                    import_formats=job.resource.SUPPORTED_FORMATS,
+                    import_formats=self.get_import_formats(),
                 )
             else:
                 context["confirm_form"] = Form()


### PR DESCRIPTION
Noticed that import format choices might be different on Import and Import Results pages.

It should either be `resource.SUPPORTED_FORMATS` or `get_import_formats()` for both pages