### PR TITLE
Fix diff color on import

### DIFF
--- a/import_export_extensions/static/import_export_extensions/css/admin/import_result_diff.css
+++ b/import_export_extensions/static/import_export_extensions/css/admin/import_result_diff.css
@@ -1,0 +1,6 @@
+ins {
+  color: black;
+}
+del {
+  color: black;
+}

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_import_results.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_import_results.html
@@ -14,6 +14,7 @@
   <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
   <script type="text/javascript" src="{% static 'admin/js/jquery.init.js' %}"></script>
   <script type="text/javascript" src="{% static 'import_export_extensions/js/admin/admin.js' %}"></script>
+  <link rel="stylesheet" type="text/css" href="{% static "import_export_extensions/css/admin/import_result_diff.css" %}"/>
 {% endblock %}
 
 


### PR DESCRIPTION
Django Admin's dark theme forces all text
to be white, which causes issues on diffs,
as diffs, BG is also having light colors as well.

![image](https://github.com/saritasa-nest/django-import-export-extensions/assets/28748495/dbd809ed-577e-4ef3-8ce3-263bafde4871)
![image](https://github.com/saritasa-nest/django-import-export-extensions/assets/28748495/da58c298-b1ba-4dd8-9034-e04542ec244d)
