### PR TITLE
Actualize docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 
 services:
   redis:

--- a/provision/ci.py
+++ b/provision/ci.py
@@ -3,7 +3,7 @@
 ##############################################################################
 from invoke import task
 
-from . import common, django, docker, linters, project, tests
+from . import common, docker, project
 
 
 @task
@@ -20,15 +20,3 @@ def set_up_hosts(context):
     common.success("Setting up hosts")
     context.run("echo \"127.0.0.1 postgres\" | sudo tee -a /etc/hosts")
     context.run("echo \"127.0.0.1 redis\" | sudo tee -a /etc/hosts")
-
-
-@task
-def start(context, check):
-    """Perform ci check"""
-    common.success("Perform CI check")
-    checks_map = dict(
-        style=linters.all,
-        migrations=django.check_new_migrations,
-        tests=tests.run_ci,
-    )
-    checks_map[check](context)

--- a/provision/docker.py
+++ b/provision/docker.py
@@ -45,7 +45,7 @@ def up_containers(
     else:
         common.success("Bring up all containers")
     up_cmd = (
-        f"docker-compose up "
+        f"docker compose up "
         f"{'-d ' if detach else ''}"
         f"{' '.join(containers)}"
     )
@@ -61,7 +61,7 @@ def up_containers(
 def stop_containers(context, containers):
     """Stop containers."""
     common.success(f"Stopping {' '.join(containers)} containers ")
-    cmd = f"docker-compose stop {' '.join(containers)}"
+    cmd = f"docker compose stop {' '.join(containers)}"
     context.run(cmd)
 
 
@@ -89,6 +89,6 @@ def clear(context):
     """Stop and remove all containers defined in docker-compose.
     Also remove images.
     """
-    common.success("Clearing docker-compose")
-    context.run("docker-compose rm -f")
-    context.run("docker-compose down -v --rmi all --remove-orphans")
+    common.success("Clearing docker compose")
+    context.run("docker compose rm -f")
+    context.run("docker compose down -v --rmi all --remove-orphans")

--- a/provision/docker.py
+++ b/provision/docker.py
@@ -87,7 +87,9 @@ def stop(context):
 @task
 def clear(context):
     """Stop and remove all containers defined in docker-compose.
+
     Also remove images.
+
     """
     common.success("Clearing docker compose")
     context.run("docker compose rm -f")

--- a/requirements/local_build.txt
+++ b/requirements/local_build.txt
@@ -16,3 +16,6 @@ pre-commit
 # Gitlint is a git commit message linter written in python: it checks your commit messages for style.
 # https://jorisroovers.com/gitlint/
 gitlint
+# TODO: Remove when issue will be resolved:
+# https://github.com/jorisroovers/gitlint/issues/535
+virtualenv==20.24.5


### PR DESCRIPTION

Since docker compose v2 has been released, we should change usage of docker compose in project.
https://docs.docker.com/compose/migrate/

- Change `docker-compose` to `docker compose`
- Update `docker-compose.yaml`

Other changes:
- Remove `ci.run` invoke since it's not used in workflow
- Freeze `virtualenv` version due https://github.com/jorisroovers/gitlint/issues/535

