### PR TITLE
Add search and ordering to API views

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ UNRELEASED
 * Extend response of import job api
 * Added support for django-import-export >= 4.0
 * Removed support for django 3.2
+* Add search and ordering to API views
 
 0.5.0 (2023-12-19)
 ------------------


### PR DESCRIPTION
Since we have validators in out projects that warn us about empty search and ordering fields. This will be convenient. Also I think ordering is usefull