### PR TITLE
Improve html templates for admin pages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,15 @@
 =======
 History
 =======
+UNRELEASED
+------------------
+* Fix progress bar on changeview for ImportJob and ExportJob
+* Improve celery-import-result page
+  * Add displaying resources for import form
+  * Fix autofill `Format` by file extension
+  * Add `Totals` section
+* Fixed display of progress bar when task is waiting to run (#68)
+* Improve progress bar style (#72)
 
 1.0.1 (2024-11-08)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,11 +5,13 @@ UNRELEASED
 ------------------
 * Fix progress bar on changeview for ImportJob and ExportJob
 * Improve celery-import-result page
+
   * Add displaying resources for import form
   * Fix autofill `Format` by file extension
   * Add `Totals` section
-* Fixed display of progress bar when task is waiting to run (#68)
-* Improve progress bar style (#72)
+
+* Fixed display of progress bar when task is waiting to run (https://github.com/saritasa-nest/django-import-export-extensions/issues/68)
+* Improve progress bar style (https://github.com/saritasa-nest/django-import-export-extensions/issues/72)
 
 1.0.1 (2024-11-08)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ UNRELEASED
   * Add displaying resources for import form
   * Fix autofill `Format` by file extension
   * Add `Totals` section
+  * Remove extra loop if errors in input file (https://github.com/saritasa-nest/django-import-export-extensions/issues/74)
 
 * Fixed display of progress bar when task is waiting to run (https://github.com/saritasa-nest/django-import-export-extensions/issues/68)
 * Improve progress bar style (https://github.com/saritasa-nest/django-import-export-extensions/issues/72)

--- a/import_export_extensions/admin/widgets.py
+++ b/import_export_extensions/admin/widgets.py
@@ -1,5 +1,6 @@
 
 from django import forms
+from django.template.loader import render_to_string
 
 
 class ProgressBarWidget(forms.Widget):
@@ -8,6 +9,8 @@ class ProgressBarWidget(forms.Widget):
     Value for `progress_bar` element is changed using JS code.
 
     """
+
+    template_name = "admin/import_export_extensions/progress_bar.html"
 
     def __init__(self, *args, **kwargs):
         """Get ``ImportJob`` or ``ExportJob`` instance from kwargs.
@@ -28,16 +31,7 @@ class ProgressBarWidget(forms.Widget):
         to send GET requests.
 
         """
-        progress_bar = f"""
-            <progress
-                value="0"
-                max="100"
-                id="progress-bar"
-                data-url="{self.url}">
-            </progress>
-        """
-
-        return progress_bar
+        return render_to_string(self.template_name, {"job_url": self.url})
 
     class Media:
         """Class with custom assets for widget."""

--- a/import_export_extensions/static/import_export_extensions/css/widgets/progress_bar.css
+++ b/import_export_extensions/static/import_export_extensions/css/widgets/progress_bar.css
@@ -4,7 +4,7 @@ progress {
   width: 100%;
   -webkit-appearance: none;
   border: none;
-  position:relative;
+  position: relative;
 }
 progress:before {
   content: attr(data-label);
@@ -24,8 +24,13 @@ progress::-webkit-progress-bar {
   background-color: var(--breadcrumbs-fg);
 }
 progress::-webkit-progress-value {
-  background-color: var(--breadcrumbs-bg);
+  background-color: var(--primary);
 }
 progress::-moz-progress-bar {
   background-color: var(--breadcrumbs-bg);
+}
+
+html[data-theme="dark"]
+progress::-webkit-progress-bar {
+  background-color: var(--darkened-bg);
 }

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_export_results.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_export_results.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block breadcrumbs_last %}
-  <a href="{% url opts|admin_urlname:'export' %}?{{request.GET.urlencode}}">
+  <a href="{% url opts|admin_urlname:'export' %}?{{ request.GET.urlencode }}">
     {% trans "Export" %}
   </a>
   &rsaquo; {% trans "Export results" %}
@@ -40,7 +40,7 @@
       <h2>
         {% trans "You can download exported data with following link" %}
       </h2>
-      <a href="{{ export_job.data_file.url }}" id="data_file">Download export data</a>
+      <a href="{{ export_job.data_file.url }}" id="data_file">{% trans "Download export data" %}</a>
     {% endif %}
   {% endblock %}
 {% endblock %}

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_export_status.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_export_status.html
@@ -42,7 +42,7 @@
         <div class="form-row">
           <label>Progress</label>
           <p id="progress_bar_html">
-            <progress max="100" id="progress-bar" data-url="{{ export_job_url }}"></progress>
+            <progress max="100" id="progress-bar" data-url="{{ export_job_url }}" data-label="Waiting..."></progress>
           </p>
         </div>
       {% endif %}

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_export_status.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_export_status.html
@@ -4,7 +4,6 @@
 
 {% comment %}
   Template to show status of export job.
-  Similar to job's admin page.
 {% endcomment %}
 
 {% block extrastyle %}

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_export_status.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_export_status.html
@@ -5,7 +5,6 @@
 {% comment %}
   Template to show status of export job.
   Similar to job's admin page.
-
 {% endcomment %}
 
 {% block extrastyle %}
@@ -24,7 +23,7 @@
 
 
 {% block breadcrumbs_last %}
-  <a href="{% url opts|admin_urlname:'export' %}?{{request.GET.urlencode}}">
+  <a href="{% url opts|admin_urlname:'export' %}?{{ request.GET.urlencode }}">
     {% trans "Export" %}
   </a>
   &rsaquo;
@@ -35,37 +34,14 @@
   <div>
     <fieldset class="module aligned collapse">
       <div class="form-row">
-        <label>Status</label><p id="current-job-status">{{ export_job.export_status|title }}</p>
+        <label>{% trans "Status" %}</label>
+        <p id="current-job-status">{{ export_job.export_status|title }}</p>
       </div>
 
       {% if export_job.export_status not in export_job.export_finished_statuses %}
         <div class="form-row">
-          <label>Progress</label>
-          <p id="progress_bar_html">
-            <progress max="100" id="progress-bar" data-url="{{ export_job_url }}" data-label="Waiting..."></progress>
-          </p>
-        </div>
-      {% endif %}
-
-      {% if export_job.export_status == export_job.ExportStatus.EXPORTED %}
-        <div class="form-row">
-          <label>Totals</label>
-          <p>
-            {% for total, stat in export_job.result.totals.items %}
-              {{ total.title }}:&nbsp; <b>{{ stat }}</b><br>
-            {% endfor %}
-          </p>
-        </div>
-      {% endif %}
-
-      {% if export_job.export_status == export_job.ExportStatus.EXPORT_ERROR %}
-        <div class="form-row">
-          <label>Error</label>
-          <p><b>{{ export_job.error_message }}</b></p>
-        </div>
-        <div class="form-row">
-          <label>Traceback</label>
-          {{ export_job.traceback | linebreaks }}
+          <label>{% trans "Progress" %}</label>
+          {% include "admin/import_export_extensions/progress_bar.html" with job_url=export_job_url %}
         </div>
       {% endif %}
     </fieldset>

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_import_results.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_import_results.html
@@ -107,59 +107,57 @@
             </li>
           {% endfor %}
         {% endfor %}
-        {% for invalid_row in result.invalid_rows %}
-          <h2>{% trans "Some rows failed to validate" %}</h2>
+        <h2>{% trans "Some rows failed to validate" %}</h2>
 
-          <p>{% trans "Please correct these errors in your data where possible, then reupload it using the form above." %}</p>
-          <table class="import-preview">
-            <thead>
+        <p>{% trans "Please correct these errors in your data where possible, then reupload it using the form above." %}</p>
+        <table class="import-preview">
+          <thead>
+            <tr>
+              <th>{% trans "Row" %}</th>
+              <th>{% trans "Errors" %}</th>
+              {% for field in result.diff_headers %}
+                <th>{{ field }}</th>
+              {% endfor %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in result.invalid_rows %}
               <tr>
-                <th>{% trans "Row" %}</th>
-                <th>{% trans "Errors" %}</th>
-                {% for field in result.diff_headers %}
-                  <th>{{ field }}</th>
+                <td>{{ row.number }} </td>
+                <td class="errors">
+                  <span class="validation-error-count">{{ row.error_count }}</span>
+                  <div class="validation-error-container">
+                    <ul class="validation-error-list">
+                      {% for field_name, error_list in row.field_specific_errors.items %}
+                        <li>
+                          <span class="validation-error-field-label">{{ field_name }}</span>
+                          <ul>
+                            {% for error in error_list %}
+                              <li>{{ error }}</li>
+                            {% endfor %}
+                          </ul>
+                        </li>
+                      {% endfor %}
+                      {% if row.non_field_specific_errors %}
+                        <li>
+                          <span class="validation-error-field-label">{% trans "Non field specific" %}</span>
+                          <ul>
+                            {% for error in row.non_field_specific_errors %}
+                              <li>{{ error }}</li>
+                            {% endfor %}
+                          </ul>
+                        </li>
+                      {% endif %}
+                    </ul>
+                  </div>
+                </td>
+                {% for field in row.values %}
+                  <td>{{ field }}</td>
                 {% endfor %}
               </tr>
-            </thead>
-            <tbody>
-              {% for row in result.invalid_rows %}
-                <tr>
-                  <td>{{ row.number }} </td>
-                  <td class="errors">
-                    <span class="validation-error-count">{{ row.error_count }}</span>
-                    <div class="validation-error-container">
-                      <ul class="validation-error-list">
-                        {% for field_name, error_list in row.field_specific_errors.items %}
-                          <li>
-                            <span class="validation-error-field-label">{{ field_name }}</span>
-                            <ul>
-                              {% for error in error_list %}
-                                <li>{{ error }}</li>
-                              {% endfor %}
-                            </ul>
-                          </li>
-                        {% endfor %}
-                        {% if row.non_field_specific_errors %}
-                          <li>
-                            <span class="validation-error-field-label">{% trans "Non field specific" %}</span>
-                            <ul>
-                              {% for error in row.non_field_specific_errors %}
-                                <li>{{ error }}</li>
-                              {% endfor %}
-                            </ul>
-                          </li>
-                        {% endif %}
-                      </ul>
-                    </div>
-                  </td>
-                  {% for field in row.values %}
-                    <td>{{ field }}</td>
-                  {% endfor %}
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        {% endfor %}
+            {% endfor %}
+          </tbody>
+        </table>
       </ul>
     {% endif %}
     {% if import_job.import_status in import_job.success_statuses %}

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_import_results.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_import_results.html
@@ -15,12 +15,18 @@
   <script type="text/javascript" src="{% static 'admin/js/jquery.init.js' %}"></script>
   <script type="text/javascript" src="{% static 'import_export_extensions/js/admin/admin.js' %}"></script>
   <link rel="stylesheet" type="text/css" href="{% static "import_export_extensions/css/admin/import_result_diff.css" %}"/>
-  <link rel="stylesheet" type="text/css" href="{% static "import_export/import.css"" %}"/>
+  <link rel="stylesheet" type="text/css" href="{% static "import_export/import.css" %}"/>
+  <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+  {% if confirm_form %}
+    {{ confirm_form.media }}
+  {% else %}
+    {{ import_form.media }}
+  {% endif %}
 {% endblock %}
 
 
 {% block breadcrumbs_last %}
-  <a href="{% url opts|admin_urlname:'import' %}?{{request.GET.urlencode}}">
+  <a href="{% url opts|admin_urlname:'import' %}?{{ request.GET.urlencode }}">
     {% trans "Import" %}
   </a>
   &rsaquo; {% trans "Import results" %}
@@ -49,6 +55,8 @@
   {% if import_form %}
     <form action="{% url opts|admin_urlname:"import" %}?{{ request.GET.urlencode }}" method="post" enctype="multipart/form-data">
       {% csrf_token %}
+
+      {% include "admin/import_export/resource_fields_list.html" with import_or_export="import" %}
 
       <fieldset class="module aligned">
         {% for field in import_form %}
@@ -155,6 +163,12 @@
       </ul>
     {% endif %}
     {% if import_job.import_status in import_job.success_statuses %}
+      <h2>{% trans "Totals" %}</h2>
+      <div>
+        {% for total, stat in import_job.result.totals.items %}
+          {{ total.title }}: <b>{{ stat }}</b><br>
+        {% endfor %}
+      </div>
       <h2>
         {% if import_job.import_status == "PARSED" %}
           {% trans "These elements will be imported successfully" %}

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_import_status.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_import_status.html
@@ -4,8 +4,6 @@
 
 {% comment %}
   Template to show status of import job.
-  Similar to job's admin page.
-
 {% endcomment %}
 
 {% block extrastyle %}
@@ -24,7 +22,7 @@
 
 
 {% block breadcrumbs_last %}
-  <a href="{% url opts|admin_urlname:'import' %}?{{request.GET.urlencode}}">
+  <a href="{% url opts|admin_urlname:'import' %}?{{ request.GET.urlencode }}">
     {% trans "Import" %}
   </a>
   &rsaquo; {% trans "Importing..." %}
@@ -35,37 +33,13 @@
 
     <fieldset class="module aligned collapse">
       <div class="form-row">
-        <label>Status</label><p id="current-job-status">{{ import_job.import_status|title }}</p>
+        <label>{% trans "Status" %}</label><p id="current-job-status">{{ import_job.import_status|title }}</p>
       </div>
 
       {% if import_job.import_status not in import_job.results_statuses %}
         <div class="form-row">
-          <label>Progress</label>
-          <p id="progress_bar_html">
-            <progress max="100" id="progress-bar" data-url="{{ import_job_url }}" data-label="Waiting..."></progress>
-          </p>
-        </div>
-      {% endif %}
-
-      {% if import_job.import_status in import_job.success_statuses %}
-        <div class="form-row">
-          <label>Totals</label>
-          <p>
-            {% for total, stat in import_job.result.totals.items %}
-              {{ total.title }}:&nbsp; <b>{{ stat }}</b><br>
-            {% endfor %}
-          </p>
-        </div>
-      {% endif %}
-
-      {% if import_job.import_status in import_job.failure_statuses %}
-        <div class="form-row">
-          <label>Error</label>
-          <p><b>{{ import_job.error_message }}</b></p>
-        </div>
-        <div class="form-row">
-          <label>Traceback</label>
-          {{ import_job.traceback | linebreaks }}
+          <label>{% trans "Progress" %}</label>
+          {% include "admin/import_export_extensions/progress_bar.html" with job_url=import_job_url %}
         </div>
       {% endif %}
     </fieldset>

--- a/import_export_extensions/templates/admin/import_export_extensions/celery_import_status.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/celery_import_status.html
@@ -38,11 +38,11 @@
         <label>Status</label><p id="current-job-status">{{ import_job.import_status|title }}</p>
       </div>
 
-      {% if import_job.import_status in import_job.progress_statuses %}
+      {% if import_job.import_status not in import_job.results_statuses %}
         <div class="form-row">
           <label>Progress</label>
           <p id="progress_bar_html">
-            <progress max="100" id="progress-bar" data-url="{{ import_job_url }}"></progress>
+            <progress max="100" id="progress-bar" data-url="{{ import_job_url }}" data-label="Waiting..."></progress>
           </p>
         </div>
       {% endif %}

--- a/import_export_extensions/templates/admin/import_export_extensions/progress_bar.html
+++ b/import_export_extensions/templates/admin/import_export_extensions/progress_bar.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+<progress max="100" id="progress-bar" data-url="{{ job_url }}" data-label={% trans "Waiting..." %}></progress>

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -28,14 +28,6 @@ urlpatterns = [re_path("^admin/", admin.site.urls), *ie_router.urls]
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns += static(
-        settings.MEDIA_URL,
-        document_root=settings.MEDIA_ROOT,
-    )
-    urlpatterns += static(
-        settings.STATIC_URL,
-        document_root=settings.STATIC_ROOT,
-    )
     urlpatterns += [
         path(
             "api/schema/",
@@ -49,3 +41,12 @@ if settings.DEBUG:
         ),
         path("__debug__/", include(debug_toolbar.urls)),
     ]
+
+    urlpatterns += static(
+        settings.MEDIA_URL,
+        document_root=settings.MEDIA_ROOT,
+    )
+    urlpatterns += static(
+        settings.STATIC_URL,
+        document_root=settings.STATIC_ROOT,
+    )


### PR DESCRIPTION
Related to [#68](https://github.com/saritasa-nest/django-import-export-extensions/issues/68#issuecomment-2491825927) and a few minor fixes)

<details>
<summary>Fix progress bar on changeview for ImportJob and ExportJob</summary>

Before:

![image](https://github.com/user-attachments/assets/a800d358-11b4-44ba-908e-ee3e6f0bbf00)

After:

![image](https://github.com/user-attachments/assets/7ea7747e-4a77-4213-a09b-0cfadb73ca70)

</details>

<details>
<summary>Improve celery-import-result page</summary>

* Add resources fields
* Fix autofill `Format` by file extension
* Add `Totals` section to celery import result

Before:

![image](https://github.com/user-attachments/assets/5e56702c-5b5a-4031-b610-2091ff8e9d1c)

After:

![image](https://github.com/user-attachments/assets/7291e14a-9b05-4343-bd77-9b9e61ac3880)

</details>

<details>
<summary>Improve progress bar style (#72) </summary>

Light theme:

![image](https://github.com/user-attachments/assets/6c0eb08e-343b-4a1c-a837-085f33bccf5e)
![image](https://github.com/user-attachments/assets/62580634-b209-4adb-8efc-06b7bb5f6e6c)

Dark theme:

![image](https://github.com/user-attachments/assets/cd88681e-ec63-436c-9394-b8946cbd64f9)
![image](https://github.com/user-attachments/assets/e0d88ce4-050c-4b98-af84-5687fa6b7ce5)

</details>

Remove useless code

* Remove extra loop in celery-import-result template if errors in input file (Relates to #74)