### PR TITLE
Add support for ordering in export

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,10 @@ UNRELEASED
 
 * Add base import/export views that only allow users to work with their own jobs (`ImportJobForUserViewSet` and `ExportJobForUserViewSet`).
 * Small actions definition refactor in `ExportJobViewSet/ExportJobViewSet` to allow easier overriding.
+* Add support for ordering in `export`
+* Add settings for DjangoFilterBackend and OrderingFilter in export api.
+`DRF_EXPORT_DJANGO_FILTERS_BACKEND` with default `django_filters.rest_framework.DjangoFilterBackend` and
+`DRF_EXPORT_ORDERING_BACKEND` with default `rest_framework.filters.OrderingFilter`.
 
 1.2.0 (2024-12-26)
 ------------------

--- a/docs/api_drf.rst
+++ b/docs/api_drf.rst
@@ -2,10 +2,19 @@
 API (Rest Framework)
 ====================
 
-.. autoclass:: import_export_extensions.api.views.ImportJobViewSet
+.. autoclass:: import_export_extensions.api.ImportJobViewSet
    :members:
 
-.. autoclass:: import_export_extensions.api.views.ExportJobViewSet
+.. autoclass:: import_export_extensions.api.ExportJobViewSet
+   :members:
+
+.. autoclass:: import_export_extensions.api.ImportJobForUserViewSet
+   :members:
+
+.. autoclass:: import_export_extensions.api.ExportJobForUserViewSet
+   :members:
+
+.. autoclass:: import_export_extensions.api.LimitQuerySetToCurrentUserMixin
    :members:
 
 .. autoclass:: import_export_extensions.api.CreateExportJob

--- a/import_export_extensions/apps.py
+++ b/import_export_extensions/apps.py
@@ -9,6 +9,11 @@ from django.utils.translation import gettext_lazy as _
 DEFAULT_MAX_DATASET_ROWS = 100000
 # After how many imported/exported rows celery task status will be updated
 DEFAULT_STATUS_UPDATE_ROW_COUNT = 100
+# Default filter class backends for export api
+DEFAULT_DRF_EXPORT_DJANGO_FILTERS_BACKEND = (
+    "django_filters.rest_framework.DjangoFilterBackend"
+)
+DEFAULT_DRF_EXPORT_ORDERING_BACKEND = "rest_framework.filters.OrderingFilter"
 
 
 class CeleryImportExport(AppConfig):
@@ -30,4 +35,14 @@ class CeleryImportExport(AppConfig):
             settings,
             "STATUS_UPDATE_ROW_COUNT",
             DEFAULT_STATUS_UPDATE_ROW_COUNT,
+        )
+        settings.DRF_EXPORT_DJANGO_FILTERS_BACKEND = getattr(
+            settings,
+            "DRF_EXPORT_DJANGO_FILTERS_BACKEND",
+            DEFAULT_DRF_EXPORT_DJANGO_FILTERS_BACKEND,
+        )
+        settings.DRF_EXPORT_ORDERING_BACKEND = getattr(
+            settings,
+            "DRF_EXPORT_ORDERING_BACKEND",
+            DEFAULT_DRF_EXPORT_ORDERING_BACKEND,
         )

--- a/test_project/fake_app/api/views.py
+++ b/test_project/fake_app/api/views.py
@@ -7,6 +7,10 @@ class ArtistExportViewSet(views.ExportJobForUserViewSet):
     """Simple ViewSet for exporting Artist model."""
 
     resource_class = SimpleArtistResource
+    export_ordering_fields = (
+        "id",
+        "name",
+    )
 
 class ArtistImportViewSet(views.ImportJobForUserViewSet):
     """Simple ViewSet for importing Artist model."""

--- a/test_project/tests/integration_tests/test_api/test_export.py
+++ b/test_project/tests/integration_tests/test_api/test_export.py
@@ -54,6 +54,24 @@ def test_export_api_create_export_job_with_invalid_filter_kwargs(
 
 
 @pytest.mark.django_db(transaction=True)
+def test_export_api_create_export_job_with_invalid_ordering(
+    admin_api_client: test.APIClient,
+):
+    """Ensure export start API with invalid ordering return an error."""
+    response = admin_api_client.post(
+        path=f"{reverse('export-artist-start')}?ordering=invalid_id",
+        data={
+            "file_format": "csv",
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.data
+    assert (
+        str(response.data["ordering"][0])
+        == "Cannot resolve keyword 'invalid_id' into field."
+    ), response.data
+
+
+@pytest.mark.django_db(transaction=True)
 def test_export_api_detail(
     admin_api_client: test.APIClient,
     artist_export_job: ExportJob,


### PR DESCRIPTION
Add support for ordering in `export`
Add settings for DjangoFilterBackend and OrderingFilter in export api. `DRF_EXPORT_DJANGO_FILTERS_BACKEND` with default
`django_filters.rest_framework.DjangoFilterBackend` and `DRF_EXPORT_ORDERING_BACKEND` with default
`rest_framework.filters.OrderingFilter`.