### PR TITLE
Add `created_by` argument to `CeleryResourceMixin`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+UNRELEASED
+------------------
+
+* Add explicit `created_by` argument to `CeleryResourceMixin` and pass it in
+`ExportJobSerializer` validation
+
 1.3.1 (2025-01-13)
 ------------------
 

--- a/import_export_extensions/api/serializers/export_job.py
+++ b/import_export_extensions/api/serializers/export_job.py
@@ -71,6 +71,7 @@ class CreateExportJob(serializers.Serializer):
         self.resource_class(
             ordering=self._ordering,
             filter_kwargs=self._filter_kwargs,
+            created_by=self._user,
             **self._resource_kwargs,
         ).get_queryset()
         return attrs

--- a/import_export_extensions/resources.py
+++ b/import_export_extensions/resources.py
@@ -40,11 +40,13 @@ class CeleryResourceMixin:
         self,
         filter_kwargs: dict[str, typing.Any] | None = None,
         ordering: collections.abc.Sequence[str] | None = None,
+        created_by: typing.Any | None = None,
         **kwargs,
     ):
         """Remember init kwargs."""
         self._filter_kwargs = filter_kwargs
         self._ordering = ordering
+        self._created_by = created_by
         self.resource_init_kwargs: dict[str, typing.Any] = kwargs
         self.total_objects_count = 0
         self.current_object_number = 0


### PR DESCRIPTION
Add explicit `created_by` argument to `CeleryResourceMixin` and pass it in `ExportJobSerializer` validation. Since it's always passed via `BaseJob` mode, it makes sense to make it explicit to `CeleryResourceMixin` users