### PR TITLE
Minor resource improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Unreleased
 ------------------
 
 * Add ability to disable celery task updates for resource
+* Make that resources will always filter queryset on export if filterset_class is present
 
 1.7.0 (2025-05-22)
 ------------------

--- a/import_export_extensions/resources.py
+++ b/import_export_extensions/resources.py
@@ -128,10 +128,10 @@ class CeleryResourceMixin:
         queryset: QuerySet,
     ) -> QuerySet:
         """Filter queryset for export."""
-        if not self._filter_kwargs:
+        if not hasattr(self, "filterset_class"):
             return queryset
         filter_instance = self.filterset_class(
-            data=self._filter_kwargs,
+            data=self._filter_kwargs or {},
         )
         if not filter_instance.is_valid():
             raise translate_validation(filter_instance.errors)


### PR DESCRIPTION
* Add the ability to disable celery updates for the resource. It's needed if we want to use a resource inside another resource, we create several datasets to assemble them into a data book
* Make sure that resources will always filter the queryset on export if filterset_class is present. Some filterclass migth have required params(fields), as of now if we pass no filter params, there is no way for this validation to run

