### PR TITLE
Fix markup in Storages doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -111,7 +111,7 @@ as the storage is not used in the implementation of ``CeleryImportAdminMixin``.
 Picking storage
 ~~~~~~~~~~~~~~~
 
-To use different storage for import/export jobs you can use `STORAGES <https://docs.djangoproject.com/en/dev/ref/settings/#storages>`.
+To use different storage for import/export jobs you can use `STORAGES <https://docs.djangoproject.com/en/dev/ref/settings/#storages>`_.
 from django.
 
 .. code-block:: python


### PR DESCRIPTION
The URL for Django storages doc was not linked properly. It is missing an underscore in the rst markup.